### PR TITLE
Yield from

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -51,6 +51,9 @@ times with multiple contexts)
 
 from __future__ import unicode_literals
 
+from contextlib import contextmanager
+import inspect
+import logging
 import re
 
 from django.template.context import (# NOQA: imported for backwards compatibility
@@ -74,10 +77,6 @@ from django.utils.text import (
 )
 from django.utils.timezone import template_localtime
 from django.utils.translation import pgettext_lazy, ugettext_lazy
-
-from contextlib import contextmanager
-import inspect
-import logging
 
 from .exceptions import TemplateSyntaxError
 
@@ -993,8 +992,9 @@ class Node(object):
         directly.
         """
         with annotate_exception(context, self.token):
-            for chunk in self.stream(context):
-                yield chunk
+            yield from self.stream(context)
+#             for chunk in self.stream(context):
+#                 yield chunk
 
     def __iter__(self):
         yield self

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -51,12 +51,9 @@ times with multiple contexts)
 
 from __future__ import unicode_literals
 
-import inspect
-import logging
 import re
-from contextlib import contextmanager
 
-from django.template.context import (  # NOQA: imported for backwards compatibility
+from django.template.context import (# NOQA: imported for backwards compatibility
     BaseContext, Context, ContextPopException, RequestContext,
 )
 from django.utils import six
@@ -77,6 +74,10 @@ from django.utils.text import (
 )
 from django.utils.timezone import template_localtime
 from django.utils.translation import pgettext_lazy, ugettext_lazy
+
+from contextlib import contextmanager
+import inspect
+import logging
 
 from .exceptions import TemplateSyntaxError
 
@@ -135,6 +136,7 @@ class VariableDoesNotExist(Exception):
 
 
 class Origin(object):
+
     def __init__(self, name, template_name=None, loader=None):
         self.name = name
         self.template_name = template_name
@@ -169,6 +171,7 @@ class StringOrigin(six.with_metaclass(DeprecationInstanceCheck, Origin)):
 
 
 class Template(object):
+
     def __init__(self, template_string, origin=None, name=None, engine=None):
         try:
             template_string = force_text(template_string)
@@ -339,6 +342,7 @@ def linebreak_iter(template_source):
 
 
 class Token(object):
+
     def __init__(self, token_type, contents, position=None, lineno=None):
         """
         A token representing a string from the template.
@@ -384,6 +388,7 @@ class Token(object):
 
 
 class Lexer(object):
+
     def __init__(self, template_string):
         self.template_string = template_string
         self.verbatim = False
@@ -434,6 +439,7 @@ class Lexer(object):
 
 
 class DebugLexer(Lexer):
+
     def tokenize(self):
         """
         Split a template string into tokens and annotates each token with its
@@ -461,6 +467,7 @@ class DebugLexer(Lexer):
 
 
 class Parser(object):
+
     def __init__(self, tokens, libraries=None, builtins=None):
         self.tokens = tokens
         self.tags = {}
@@ -672,6 +679,7 @@ class FilterExpression(object):
         >>> fe.var
         <Variable: 'variable'>
     """
+
     def __init__(self, token, parser):
         self.token = token
         matches = filter_re.finditer(token)
@@ -771,6 +779,7 @@ class FilterExpression(object):
                                       (name, alen - dlen, plen))
 
         return True
+
     args_check = staticmethod(args_check)
 
     def __str__(self):
@@ -898,7 +907,7 @@ class Variable(object):
                             current = current[int(bit)]
                         except (IndexError,  # list index out of range
                                 ValueError,  # invalid literal for int()
-                                KeyError,    # current is a dict without `int(bit)` key
+                                KeyError,  # current is a dict without `int(bit)` key
                                 TypeError):  # unsubscriptable object
                             raise VariableDoesNotExist("Failed lookup for key "
                                                        "[%s] in %r",
@@ -1019,9 +1028,9 @@ class NodeList(list):
         for node in self:
             if isinstance(node, Node):
                 for bit in node.stream_annotated(context):
-                    yield mark_safe(force_text(bit))
+                    yield force_text(bit)
             else:
-                yield mark_safe(force_text(node))
+                yield force_text(node)
 
     def get_nodes_by_type(self, nodetype):
         "Return a list of all nodes of the given type"
@@ -1032,6 +1041,7 @@ class NodeList(list):
 
 
 class TextNode(Node):
+
     def __init__(self, s):
         self.s = s
 
@@ -1060,6 +1070,7 @@ def render_value_in_context(value, context):
 
 
 class VariableNode(Node):
+
     def __init__(self, filter_expression):
         self.filter_expression = filter_expression
 

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -1,11 +1,11 @@
 """Default tags used by the template system, available to all templates."""
 from __future__ import unicode_literals
 
+from datetime import datetime
+from itertools import cycle as itertools_cycle, groupby
 import re
 import sys
 import warnings
-from datetime import datetime
-from itertools import cycle as itertools_cycle, groupby
 
 from django.conf import settings
 from django.utils import six, timezone
@@ -30,6 +30,7 @@ register = Library()
 
 class AutoEscapeControlNode(Node):
     """Implements the actions of the autoescape tag."""
+
     def __init__(self, setting, nodelist):
         self.setting, self.nodelist = setting, nodelist
 
@@ -45,18 +46,20 @@ class AutoEscapeControlNode(Node):
         context.autoescape = self.setting
         for chunk in self.nodelist.render(context, stream=True):
             if self.setting:
-                yield mark_safe(chunk)
+                yield chunk
             else:
                 yield chunk
         context.autoescape = old_setting
 
 
 class CommentNode(Node):
+
     def render(self, context):
         return ''
 
 
 class CsrfTokenNode(Node):
+
     def render(self, context):
         csrf_token = context.get('csrf_token')
         if csrf_token:
@@ -77,6 +80,7 @@ class CsrfTokenNode(Node):
 
 
 class CycleNode(Node):
+
     def __init__(self, cyclevars, variable_name=None, silent=False):
         self.cyclevars = cyclevars
         self.variable_name = variable_name
@@ -96,6 +100,7 @@ class CycleNode(Node):
 
 
 class DebugNode(Node):
+
     def render(self, context):
         from pprint import pformat
         output = [force_text(pformat(val)) for val in context]
@@ -105,6 +110,7 @@ class DebugNode(Node):
 
 
 class FilterNode(Node):
+
     def __init__(self, filter_expr, nodelist):
         self.filter_expr, self.nodelist = filter_expr, nodelist
 
@@ -119,6 +125,7 @@ class FilterNode(Node):
 
 
 class FirstOfNode(Node):
+
     def __init__(self, variables, asvar=None):
         self.vars = variables
         self.asvar = asvar
@@ -341,12 +348,12 @@ class IfNode(Node):
     def stream(self, context):
         for condition, nodelist in self.conditions_nodelists:
 
-            if condition is not None:           # if / elif clause
+            if condition is not None:  # if / elif clause
                 try:
                     match = condition.eval(context)
                 except VariableDoesNotExist:
                     match = None
-            else:                               # else clause
+            else:  # else clause
                 match = True
 
             if match:
@@ -356,6 +363,7 @@ class IfNode(Node):
 
 
 class LoremNode(Node):
+
     def __init__(self, count, method, common):
         self.count, self.method, self.common = count, method, common
 
@@ -374,6 +382,7 @@ class LoremNode(Node):
 
 
 class RegroupNode(Node):
+
     def __init__(self, target, expression, var_name):
         self.target, self.expression = target, expression
         self.var_name = var_name
@@ -401,11 +410,13 @@ class RegroupNode(Node):
 
 
 class LoadNode(Node):
+
     def render(self, context):
         return ''
 
 
 class NowNode(Node):
+
     def __init__(self, format_string, asvar=None):
         self.format_string = format_string
         self.asvar = asvar
@@ -422,6 +433,7 @@ class NowNode(Node):
 
 
 class SpacelessNode(Node):
+
     def __init__(self, nodelist):
         self.nodelist = nodelist
 
@@ -453,6 +465,7 @@ class TemplateTagNode(Node):
 
 
 class URLNode(Node):
+
     def __init__(self, view_name, args, kwargs, asvar):
         self.view_name = view_name
         self.args = args
@@ -493,6 +506,7 @@ class URLNode(Node):
 
 
 class VerbatimNode(Node):
+
     def __init__(self, content):
         self.content = content
 
@@ -501,6 +515,7 @@ class VerbatimNode(Node):
 
 
 class WidthRatioNode(Node):
+
     def __init__(self, val_expr, max_expr, max_width, asvar=None):
         self.val_expr = val_expr
         self.max_expr = max_expr
@@ -534,6 +549,7 @@ class WidthRatioNode(Node):
 
 
 class WithNode(Node):
+
     def __init__(self, var, name, nodelist, extra_context=None):
         self.nodelist = nodelist
         # var and name are legacy attributes, being left in case they are used
@@ -903,6 +919,7 @@ def ifnotequal(parser, token):
 
 
 class TemplateLiteral(Literal):
+
     def __init__(self, value, text):
         self.value = value
         self.text = text  # for better error messages


### PR DESCRIPTION
Never mind automatic style changes. I've removed `mark_safe()` calls on chunks, and replaced `for .. yield` with `yield from`. It requires Python 3 though. Now streaming version is *faster* than django original:

STREAMING BRANCH`(stream=False)`:
```
Server Software:        WSGIServer/0.2
Server Hostname:        0.0.0.0
Server Port:            8001

Document Path:          /polls/streaming/
Document Length:        268906 bytes

Concurrency Level:      1
Time taken for tests:   14.819 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      26909300 bytes
HTML transferred:       26890600 bytes
Requests per second:    6.75 [#/sec] (mean)
Time per request:       148.193 [ms] (mean)
Time per request:       148.193 [ms] (mean, across all concurrent requests)
Transfer rate:          1773.27 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       1
Processing:   136  148   8.4    146     191
Waiting:      136  148   8.4    145     191
Total:        136  148   8.4    146     191

Percentage of the requests served within a certain time (ms)
  50%    146
  66%    149
  75%    151
  80%    153
  90%    157
  95%    166
  98%    172
  99%    191
 100%    191 (longest request)
```

ORIGINAL:
```
Server Software:        WSGIServer/0.2
Server Hostname:        0.0.0.0
Server Port:            8001

Document Path:          /polls/streaming/
Document Length:        268906 bytes

Concurrency Level:      1
Time taken for tests:   17.126 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      26909300 bytes
HTML transferred:       26890600 bytes
Requests per second:    5.84 [#/sec] (mean)
Time per request:       171.258 [ms] (mean)
Time per request:       171.258 [ms] (mean, across all concurrent requests)
Transfer rate:          1534.44 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   137  171  24.6    163     236
Waiting:      137  171  24.6    163     235
Total:        137  171  24.6    164     236

Percentage of the requests served within a certain time (ms)
  50%    164
  66%    178
  75%    193
  80%    198
  90%    211
  95%    217
  98%    226
  99%    236
 100%    236 (longest request)
```